### PR TITLE
(openbao-corrupted-mount): add lab

### DIFF
--- a/openbao-corrupted-mount/assets/namespace.json
+++ b/openbao-corrupted-mount/assets/namespace.json
@@ -1,0 +1,8 @@
+{
+  "id": "",
+  "uuid": "",
+  "path": "lab-b/",
+  "tainted": false,
+  "unlock_key": "",
+  "custom_metadata": {}
+}

--- a/openbao-corrupted-mount/assets/openbao.hcl
+++ b/openbao-corrupted-mount/assets/openbao.hcl
@@ -1,0 +1,49 @@
+ui            = true
+cluster_addr  = "https://127.0.0.1:30201"
+api_addr      = "https://127.0.0.1:30200"
+raw_storage_endpoint = true
+
+listener "tcp" {
+  tls_disable = 1
+  address = "[::]:30200"
+  cluster_address = "[::]:30201"
+}
+storage "raft" {
+  path = "/opt/openbao/data"
+}
+seal "static" {
+  current_key_id = "20260302-1"
+  current_key = "file:///etc/openbao/unseal/unseal-20260302-1.key"
+}
+
+audit "file" "to-file" {
+  description = "File audit device"
+  options {
+    file_path = "/var/log/openbao/audit.log"
+  }
+}
+
+initialize "init-config" {
+  request "admin-policy" {
+    operation = "create"
+    path = "sys/policies/acl/admin"
+    data = {
+      "policy" = "path \"*\" {\n    capabilities = [\"create\", \"read\", \"patch\", \"update\", \"delete\", \"list\", \"sudo\"]\n}\n"
+    }
+  }
+  request "enable-userpass" {
+    operation = "create"
+    path = "sys/auth/userpass"
+    data = {
+      type = "userpass"
+    }
+  }
+  request "create-admin" {
+    operation = "create"
+    path = "auth/userpass/users/admin"
+    data = {
+      password = "admin123"
+      token_policies = "admin"
+    }
+  }
+}

--- a/openbao-corrupted-mount/assets/openbao.service
+++ b/openbao-corrupted-mount/assets/openbao.service
@@ -1,0 +1,30 @@
+[Unit]
+Description="OpenBao Secret Management"
+Documentation=https://openbao.org/docs/
+Requires=network-online.target
+After=network-online.target
+ConditionFileNotEmpty=/etc/openbao/openbao.hcl
+
+[Service]
+User=openbao
+Group=openbao
+ProtectSystem=full
+ProtectHome=read-only
+PrivateTmp=yes
+PrivateDevices=yes
+SecureBits=keep-caps
+AmbientCapabilities=CAP_IPC_LOCK
+CapabilityBoundingSet=CAP_SYSLOG CAP_IPC_LOCK
+NoNewPrivileges=yes
+ExecStart=/usr/local/bin/bao server -config=/etc/openbao/openbao.hcl
+ExecReload=/bin/kill --signal HUP $MAINPID
+KillMode=process
+KillSignal=SIGINT
+Restart=on-failure
+RestartSec=5
+TimeoutStopSec=30
+LimitNOFILE=65536
+LimitMEMLOCK=infinity
+
+[Install]
+WantedBy=multi-user.target

--- a/openbao-corrupted-mount/finish.md
+++ b/openbao-corrupted-mount/finish.md
@@ -1,0 +1,7 @@
+# Congrats!
+
+You completed this lab.
+
+Note that if we had a snapshot at hand, it would probably have been easier to just restore the snapshot, considering this was a new namespace with no data.
+
+If you encountered any problem with the lab content, please create [an issue on our GitHub repository](https://github.com/adfinis/openbao-labs).

--- a/openbao-corrupted-mount/finish.md
+++ b/openbao-corrupted-mount/finish.md
@@ -2,6 +2,6 @@
 
 You completed this lab.
 
-Note that if we had a snapshot at hand, it would probably have been easier to just restore the snapshot, considering this was a new namespace with no data.
+Note that if we had a snapshot at hand, restoring the snapshot could have been an option. However, restoring larger instances can be time-consuming and may result in the loss of any data generated since the last snapshot.
 
 If you encountered any problem with the lab content, please create [an issue on our GitHub repository](https://github.com/adfinis/openbao-labs).

--- a/openbao-corrupted-mount/index.json
+++ b/openbao-corrupted-mount/index.json
@@ -1,0 +1,42 @@
+{
+  "title": "Fire Drill: Corrupted Namespace Mount",
+  "description": "Learn how to use recovery to fix a corrupted",
+  "details": {
+    "intro": {
+      "text": "intro.md",
+      "foreground":"scripts/foreground.sh",
+      "background":"scripts/background.sh"
+    },
+    "steps": [
+      {
+        "title": "Context",
+        "text": "step1/text.md"
+      },
+      {
+        "title": "Mount table corruption",
+        "text": "step2/text.md",
+        "foreground":"step2/scripts/foreground.sh",
+        "background":"step2/scripts/background.sh"
+      },
+      {
+        "title": "Start OpenBao in recovery mode",
+        "text": "step3/text.md"
+      },
+      {
+        "title": "Fix corrupt namespace mount",
+        "text": "step4/text.md"
+      }
+    ],
+    "assets": {
+      "host01": [
+        {"file": "**", "target": "/root/assets", "chmod": "+rwx"}
+      ]
+    },
+    "finish": {
+      "text": "finish.md"
+    }
+  },
+  "backend": {
+    "imageid": "kubernetes-kubeadm-1node"
+  }
+}

--- a/openbao-corrupted-mount/index.json
+++ b/openbao-corrupted-mount/index.json
@@ -1,6 +1,6 @@
 {
   "title": "Fire Drill: Corrupted Namespace Mount",
-  "description": "Learn how to use recovery to fix a corrupted",
+  "description": "Learn how to use recovery mode to fix a corrupted namespace mount",
   "details": {
     "intro": {
       "text": "intro.md",

--- a/openbao-corrupted-mount/intro.md
+++ b/openbao-corrupted-mount/intro.md
@@ -1,0 +1,7 @@
+# Welcome !
+
+![OpenBao logo](https://raw.githubusercontent.com/openbao/artwork/main/color/openbao-color.svg)
+
+In this scenario, we will see what happens when an audit device fails, how to recover and prevent future issues.
+
+If you encounter any problem with the lab content, please create [an issue on our GitHub repository](https://github.com/adfinis/openbao-labs).

--- a/openbao-corrupted-mount/intro.md
+++ b/openbao-corrupted-mount/intro.md
@@ -2,6 +2,6 @@
 
 ![OpenBao logo](https://raw.githubusercontent.com/openbao/artwork/main/color/openbao-color.svg)
 
-In this scenario, we will see what happens when an audit device fails, how to recover and prevent future issues.
+In this scenario, we will simulate a mount corruption in OpenBao and use recovery mode to restore the service.
 
 If you encounter any problem with the lab content, please create [an issue on our GitHub repository](https://github.com/adfinis/openbao-labs).

--- a/openbao-corrupted-mount/scripts/background.sh
+++ b/openbao-corrupted-mount/scripts/background.sh
@@ -1,0 +1,31 @@
+#This lab relies on a bug that exists only in OpenBao <2.5.x
+export BAO_CLI_VERSION=2.5.4
+
+wget https://github.com/openbao/openbao/releases/download/v$BAO_CLI_VERSION/bao_${BAO_CLI_VERSION}_Linux_x86_64.tar.gz
+tar xzf bao_${BAO_CLI_VERSION}_Linux_x86_64.tar.gz
+mv bao /usr/local/bin/
+
+setcap cap_ipc_lock=+ep /usr/local/bin/bao
+
+sudo useradd --system --home /etc/openbao --shell /bin/false openbao
+mkdir -p /etc/openbao/unseal /opt/openbao/data /var/log/openbao
+chown -R openbao:openbao /var/log/openbao /etc/openbao /opt/openbao
+sudo chmod -R 750 /etc/openbao /opt/openbao /var/log/openbao
+
+# unseal key
+openssl rand -out /etc/openbao/unseal/unseal-20260302-1.key 32
+
+mv /root/assets/openbao.hcl /etc/openbao/
+mv /root/assets/openbao.service /etc/systemd/system/openbao.service
+
+sudo systemctl daemon-reload
+sudo systemctl enable --now openbao
+
+sleep 30s
+
+export BAO_ADDR=$(sed 's/PORT/30200/g' /etc/killercoda/host)
+bao login -method=userpass username=admin password=admin123
+bao write -format=json sys/rotate/recovery/init secret_shares=1 secret_threshold=1 | jq -r '.data.keys[0]'> /root/assets/recovery-key.txt
+bao namespace create lab-a
+
+echo done > /tmp/ready

--- a/openbao-corrupted-mount/scripts/foreground.sh
+++ b/openbao-corrupted-mount/scripts/foreground.sh
@@ -1,0 +1,4 @@
+echo Preparing the environment...
+while [ ! -f /tmp/ready ]; do sleep 1; done
+export BAO_ADDR=$(sed 's/PORT/30200/g' /etc/killercoda/host)
+echo Ready to start!

--- a/openbao-corrupted-mount/step1/text.md
+++ b/openbao-corrupted-mount/step1/text.md
@@ -1,0 +1,19 @@
+> **Wait for the environment setup to complete. Once you see the "Ready to start!" message in the shell, you can get going.**
+
+## Context 
+
+An OpenBao server is already deployed with a Raft storage backend. A [userpass](https://openbao.org/docs/auth/userpass/) authentication method is already pre-configured. The `BAO_ADDR` environment variable has already been set for you.
+
+You can log in with the following credentials:
+> * username: admin
+> * password: admin123
+
+* `bao login -method=userpass username=admin`
+
+OpenBao is installed locally and running as a systemd service.
+
+* `systemctl status openbao`
+
+There is also a namespace `lab-a` already provisioned.
+
+* `bao namespace list`

--- a/openbao-corrupted-mount/step2/scripts/background.sh
+++ b/openbao-corrupted-mount/step2/scripts/background.sh
@@ -1,0 +1,12 @@
+export BAO_ADDR=$(sed 's/PORT/30200/g' /etc/killercoda/host)
+
+bao login -method=userpass username=admin password=admin123
+bao namespace create lab-b
+
+for id in $(bao list -format=json sys/raw/core/namespaces | jq -r '.[]');do
+  if [[ $(bao read -field=value sys/raw/core/namespaces/$id | jq -r '.path') == "lab-b/" ]]; then
+    bao write sys/raw/core/namespaces/$id namespace=borked
+  fi
+done;
+
+systemctl restart openbao

--- a/openbao-corrupted-mount/step2/scripts/background.sh
+++ b/openbao-corrupted-mount/step2/scripts/background.sh
@@ -10,3 +10,5 @@ for id in $(bao list -format=json sys/raw/core/namespaces | jq -r '.[]');do
 done;
 
 systemctl restart openbao
+
+echo done > /tmp/ready

--- a/openbao-corrupted-mount/step2/scripts/foreground.sh
+++ b/openbao-corrupted-mount/step2/scripts/foreground.sh
@@ -1,0 +1,4 @@
+echo Preparing the environment...
+while [ ! -f /tmp/ready ]; do sleep 1; done
+export BAO_ADDR=$(sed 's/PORT/30200/g' /etc/killercoda/host)
+echo Ready to start!

--- a/openbao-corrupted-mount/step2/text.md
+++ b/openbao-corrupted-mount/step2/text.md
@@ -1,0 +1,13 @@
+A new namespace `lab-b` was created, but the cluster crashed during the process. This ended up corrupting the mount table of the OpenBao storage database.
+OpenBao is now unable to start correctly:
+
+* `journalctl -eu openbao`
+
+```
+[ERROR] core: post-unseal setup failed: error="error loading initial namespaces: failed to decode namespace fba3de26-98c7-bfb1-b6ec-9b37da078548 (page 0 / index 1): invalid character 'b' looking for beginning of value"
+[ERROR] core: failed to list entries in core/leader: error="context canceled"
+```
+
+The server recovery key has been saved for you in `/root/assets/recovery-key.text`.
+
+With this, you can now try to solve the issue by yourself or follow along in the next step. (Hint: this involves [recovery mode](https://openbao.org/docs/concepts/recovery-mode/))

--- a/openbao-corrupted-mount/step3/text.md
+++ b/openbao-corrupted-mount/step3/text.md
@@ -1,0 +1,71 @@
+Since we cannot interact with OpenBao, our first step should be to run the server in recovery mode.
+
+For this we want to override the systemd unit and add the `-recovery` flag:
+* `systemctl edit openbao`
+
+> Side note: the empty `ExecStart=` is needed because it's parsed by systemd as a list. See [here](https://www.freedesktop.org/software/systemd/man/latest/systemd.unit.html#Examples): "...if one wants to remove entries from a setting that is parsed as a list (and is not a dependency), such as AssertPathExists= (or e.g. ExecStart= in service units), one needs to first clear the list before re-adding all entries except the one that is to be removed".
+
+```
+[Service]
+ExecStart=
+ExecStart=/usr/local/bin/bao server -config=/etc/openbao/openbao.hcl -recovery
+```
+
+Then restart the service:
+* `systemctl restart openbao`
+
+OpenBao should now start in recovery mode:
+* `journalctl -eu openbao`
+
+```
+==> OpenBao server configuration:
+    Seal Type: static
+    Static KMS Key ID: 20260302-1
+    Cluster Address: https://127.0.0.1:30201
+    Go Version: go1.25.10
+    Log Level:
+    Recovery Mode: true
+    Storage: raft
+    Version: OpenBao v2.5.4, built 2026-05-20T16:08:53Z
+    Version Sha: 4f6d47246a053375271a5fd8af85c3b75695aa46
+```
+
+## Generate recovery token
+
+Now we need to generate a recovery token.
+
+Start by generating an OTP:
+* `bao operator generate-root -generate-otp -recovery-token`
+
+Initiate the recovery token generation using the OTP:
+* `bao operator generate-root -init -otp=<otp> -recovery-token`
+
+This gives us a `nonce` that we will need to submit in the following steps.
+```bash
+Nonce         9e2de75b-e1aa-b358-eaaf-c97dbd02fc31
+Started       true
+Progress      0/1
+Complete      false
+OTP Length    28
+```
+
+Submit the recovery key share we retrieved earlier:
+* `bao operator generate-root -nonce <nonce> -recovery-token $(cat /root/assets/recovery-key.txt)`
+
+This will give an encoded recovery token:
+```bash
+Nonce            9e2de75b-e1aa-b358-eaaf-c97dbd02fc31
+Started          true
+Progress         1/1
+Complete         true
+Encoded Token    JxIFaxFAIncVI0QfdC8tEXYBEAgeADwPfDclFA
+```
+
+We can now decode the recovery token:
+* `bao operator generate-root -decode=<encoded-token> -otp=<otp> -recovery-token`
+
+We can then use that token to send requests against `sys/raw`:
+```bash
+export BAO_TOKEN=<recovery-token>
+bao list sys/raw
+```

--- a/openbao-corrupted-mount/step4/text.md
+++ b/openbao-corrupted-mount/step4/text.md
@@ -1,0 +1,151 @@
+We now know from the logs the namespace ID that was causing issues.
+
+```
+[ERROR] core: post-unseal setup failed: error="error loading initial namespaces: failed to decode namespace fba3de26-98c7-bfb1-b6ec-9b37da078548 (page 0 / index 1): invalid character 'b' looking for beginning of value"
+```
+
+Let's have a look at this namespace in the core store:
+* `bao read -field=value sys/raw/core/namespaces/fba3de26-98c7-bfb1-b6ec-9b37da078548`
+
+```bash
+Error reading sys/raw/core/namespaces/fba3de26-98c7-bfb1-b6ec-9b37da078548: Error making API request.
+
+URL: GET https://b39fe40b3cd6-10-244-7-24-30200.spch.r.killercoda.com/v1/sys/raw/core/namespaces/fba3de26-98c7-bfb1-b6ec-9b37da078548
+Code: 400. Errors:
+
+* 'data' being decompressed is empty
+```
+
+Looks bad, but this probably explains the issue. Let's take a look at a different namespace to see how it should look:
+
+* `bao list sys/raw/core/namespaces`
+
+```
+Keys
+----
+3ad6dce6-6f4f-5995-18a8-b3705d0b402b
+fba3de26-98c7-bfb1-b6ec-9b37da078548
+```
+
+* `bao read -field=value sys/raw/core/namespaces/3ad6dce6-6f4f-5995-18a8-b3705d0b402b | jq`
+
+```json
+{
+  "id": "qq0Pco",
+  "uuid": "3ad6dce6-6f4f-5995-18a8-b3705d0b402b",
+  "path": "lab-a/",
+  "tainted": false,
+  "unlock_key": "",
+  "custom_metadata": {}
+}
+```
+This key stores some basic information about the namespace. If we can re-create the key for the namespace `lab-b`, we should be able to restore the service.
+
+A JSON file with the same structure was already prepared for you at `/root/assets/namespace.json`. From there we only need to add the `id` and `uuid`. The `uuid` we can already figure out from the log, which only leaves us with the `id`:
+
+```json
+{
+  "id": "",
+  "uuid": "fba3de26-98c7-bfb1-b6ec-9b37da078548",
+  "path": "lab-b/",
+  "tainted": false,
+  "unlock_key": "",
+  "custom_metadata": {}
+}
+```
+
+We will probably be able to find that out in the namespace store.
+
+> Notice the difference: we removed the `core`. Instead of checking the namespace mount in the core store, we are now looking at the namespace store itself. This is where we would find information about secrets engines and auth methods in the namespace itself:
+
+* `bao list sys/raw/namespaces/fba3de26-98c7-bfb1-b6ec-9b37da078548`
+
+```bash
+Keys
+----
+auth/
+local-mounts/
+mounts/
+```
+
+Let's check any of the secrets engines in that namespace:
+
+* `bao list sys/raw/namespaces/fba3de26-98c7-bfb1-b6ec-9b37da078548/core/mounts`
+
+```
+Keys
+----
+44d68d81-4e4d-2fb6-bfaf-5945a92049eb
+508d0ba4-6df9-893b-0230-cedcc1c45411
+``` 
+
+* `bao read -field=value sys/raw/namespaces/fba3de26-98c7-bfb1-b6ec-9b37da078548/core/mounts/44d68d81-4e4d-2fb6-bfaf-5945a92049eb | jq`
+
+Here we can see a `namespace_id`:
+```json
+{
+  "table": "mounts",
+  "path": "sys/",
+  "type": "ns_system",
+  "description": "system endpoints used for control, policy and debugging",
+  "uuid": "44d68d81-4e4d-2fb6-bfaf-5945a92049eb",
+  "backend_aware_uuid": "e4e9da74-c9e8-c653-d47c-ba165bfc0399",
+  "accessor": "system_02421d5c",
+  "config": {
+    "passthrough_request_headers": [
+      "Accept"
+    ]
+  },
+  "options": null,
+  "local": false,
+  "seal_wrap": true,
+  "namespace_id": "YNToiD", # this line here
+  "running_plugin_version": "v2.4.3+builtin.bao"
+}
+```
+
+Let's add that to our file from earlier and try to rewrite the key:
+```json
+{
+  "id": "YNToiD",
+  "uuid": "fba3de26-98c7-bfb1-b6ec-9b37da078548",
+  "path": "lab-b/",
+  "tainted": false,
+  "unlock_key": "",
+  "custom_metadata": {}
+}
+```
+
+* `bao write sys/raw/core/namespaces/fba3de26-98c7-bfb1-b6ec-9b37da078548 value=@assets/namespace.json`
+
+We can quickly check that we are now able to read the key again:
+
+* `bao read -field=value sys/raw/core/namespaces/fba3de26-98c7-bfb1-b6ec-9b37da078548 | jq`
+
+```json
+{
+  "id": "YNToiD",
+  "uuid": "fba3de26-98c7-bfb1-b6ec-9b37da078548",
+  "path": "lab-b/",
+  "tainted": false,
+  "unlock_key": "",
+  "custom_metadata": {}
+}
+```
+
+We can try to restart OpenBao in normal mode again:
+* `systemctl revert openbao`
+* `systemctl restart openbao`
+
+If you take a look at the logs, no more errors should appear and OpenBao should start normally:
+* `journalctl -eu openbao`
+
+We can verify that all namespaces can be listed. First `unset BAO_TOKEN` to ensure you are not using the recovery token, and log in again if needed.
+
+* `bao namespace list`
+```
+Keys
+----
+lab-a/
+lab-b/
+```


### PR DESCRIPTION
This adds a "fire-drill" lab that involves using recovery mode to fix a corrupted namespace mount.