### PR TITLE
chore(openbao-recovery-mode): align lab name by switching to uppercase

### DIFF
--- a/openbao-recovery-mode/index.json
+++ b/openbao-recovery-mode/index.json
@@ -1,5 +1,5 @@
 {
-  "title": "OpenBao recovery mode",
+  "title": "OpenBao Recovery Mode",
   "description": "Learn about OpenBao recovery mode",
   "details": {
     "intro": {


### PR DESCRIPTION
A simple chore PR to align the name of the Recovery Mode lab with the existing uppercase schema.